### PR TITLE
Setting different port numbers for each module #4

### DIFF
--- a/module-api/src/main/resources/application.properties
+++ b/module-api/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=module-api
+server.port=6001

--- a/module-batch/src/main/resources/application.properties
+++ b/module-batch/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=module-batch
+server.port=6002


### PR DESCRIPTION
### 배경

- booooomb 프로젝트 backend 는 api / batch 가 멀티모듈로서 분리되어 있습니다. 
- Infra 환경 구성 시, API 는 10,000 이상의 포트를 사용할 예정입니다. 
- batch 모듈은 ingress되는 port를 열어두지 않을 예정입니다. 
- 현재 api/batch 모듈의 application.properties( 추후 application.yml 로 수정 예정 ) 에서 server.port가 지정되어 있지 않아, localhost에서 두개의 모듈을 구동 시 아래와 같은 에러가 발생합니다. 
```console
   ***************************
APPLICATION FAILED TO START
***************************

Description:

Web server failed to start. Port 8080 was already in use.

Action:

Identify and stop the process that's listening on port 8080 or configure this application to listen on another port.
```

### 작업 내용
- 모듈별로 port 번호 분리 (참고자료: [피해야할 포트 번호](https://siane.tistory.com/39))
  - api 모듈의 port 번호: 6001 
  - batch 모듈의 port 번호: 6002 

### 기대 효과
- local 에서 api / batch 구동 시, 서로 포트 충돌이 발생하지 않고 정상적으로 구동되기를 희망합니다. 